### PR TITLE
Fixed windows builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 target/
 
 *.lock
+
+.vscode/
+
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ num-derive = "0.3.3"
 num-traits = "0.2.15"
 derive_is_enum_variant = "0.1.1"
 derive_builder = "0.11.2"
-stereokit-sys = "2.0.0"
+stereokit-sys = "2.0.1"
 once_cell = "1.16.0"
 bitflags = "1.3.2"
 ustr = "0.9.0"
@@ -46,4 +46,3 @@ ndk-context = "0.1.1"
 [dev-dependencies]
 anyhow = "1.0.61"
 glam = {version = "0.22.0", features = ["mint"]}
-

--- a/src/info.rs
+++ b/src/info.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use stereokit_sys::sk_system_info;
 
-use crate::StereoKit;
+use crate::{StereoKit, values::IntType};
 
 // pub const display__display_none: display_ = 0;
 // pub const display__display_opaque: display_ = 1;
@@ -39,7 +39,7 @@ impl StereoKit {
 	pub fn system_info(&self) -> SystemInfo {
 		let info = unsafe { sk_system_info() };
 		SystemInfo {
-			display_type: Display::try_from_primitive(info.display_type).unwrap(),
+			display_type: Display::try_from_primitive(info.display_type as u32).unwrap(),
 			display_width: info.display_width as u32,
 			display_height: info.display_height as u32,
 			spatial_bridge_present: info.spatial_bridge_present > 0,

--- a/src/input.rs
+++ b/src/input.rs
@@ -2,7 +2,7 @@
 
 use crate::{
 	pose::Pose,
-	values::{Quat, Vec2, Vec3},
+	values::{Quat, Vec2, Vec3, IntType},
 	StereoKit,
 };
 use bitflags::bitflags;
@@ -132,7 +132,7 @@ bitflags! {
 }
 impl StereoKit {
 	pub fn input_key(&self, key: Key) -> ButtonState {
-		ButtonState::from_bits_truncate(unsafe { input_key(key as key_) })
+		ButtonState::from_bits_truncate(unsafe { input_key(key as key_) } as u32)
 	}
 }
 
@@ -230,15 +230,15 @@ pub struct Controller {
 
 impl StereoKit {
 	pub fn input_hand(&self, handed: Handed) -> &Hand {
-		unsafe { std::mem::transmute(&*stereokit_sys::input_hand(handed as u32)) }
+		unsafe { std::mem::transmute(&*stereokit_sys::input_hand(handed as i32)) }
 	}
 	pub fn input_controller(&self, handed: Handed) -> &Controller {
-		unsafe { std::mem::transmute(&*stereokit_sys::input_controller(handed as u32)) }
+		unsafe { std::mem::transmute(&*stereokit_sys::input_controller(transmute::<u32,IntType>(handed as u32))) }
 	}
 	pub fn input_controller_menu(&self) -> ButtonState {
 		unsafe { std::mem::transmute(stereokit_sys::input_controller_menu()) }
 	}
 	pub fn input_hand_visible(&self, handed: Handed, visible: bool) {
-		unsafe { input_hand_visible(handed as u32, visible as bool32_t)}
+		unsafe { input_hand_visible(transmute::<u32,IntType>(handed as u32), visible as bool32_t)}
 	}
 }

--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -8,12 +8,12 @@ use std::cell::{Ref, RefCell};
 use std::ffi::{c_void, CString};
 use std::fmt::Error;
 use std::marker::PhantomData;
-use std::os::unix::thread;
 use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
 use std::ptr::{null, null_mut};
 use std::rc::{Rc, Weak};
 use std::sync::Mutex;
+use std::thread;
 use std::{mem, ptr};
 use stereokit_sys::{
 	assets_releaseref_threadsafe, bool32_t, color32, depth_mode_, display_blend_, display_mode_,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,0 @@
-use stereokit::Settings;
-
-fn main() {
-  let stereokit = Settings::default().init().unwrap();
-	stereokit.run(|_, _| {}, |_| {});
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,6 @@
+use stereokit::Settings;
+
+fn main() {
+  let stereokit = Settings::default().init().unwrap();
+	stereokit.run(|_, _| {}, |_| {});
+}

--- a/src/material.rs
+++ b/src/material.rs
@@ -1,11 +1,12 @@
 use crate::lifecycle::StereoKitInstanceWrapper;
 use crate::shader::Shader;
 use crate::texture::Texture;
-use crate::values::{vec2_from, Color128, Matrix, Vec2, Vec3, Vec4};
+use crate::values::{vec2_from, Color128, Matrix, Vec2, Vec3, Vec4, IntType};
 use crate::StereoKit;
 use num_enum::TryFromPrimitive;
 use std::ffi::{c_void, CString};
 use std::fmt::Error;
+use std::mem::transmute;
 use std::ptr::NonNull;
 use std::rc::{Rc, Weak};
 use stereokit_sys::{
@@ -34,21 +35,21 @@ pub trait MaterialParameter {
 }
 
 impl MaterialParameter for Vec2 {
-	const SK_TYPE: u32 = material_param__material_param_vector2;
+	const SK_TYPE: u32 = unsafe { transmute::<IntType, u32>(material_param__material_param_vector2) };
 
 	fn as_raw(&self) -> *const c_void {
 		&self as *const _ as *const c_void
 	}
 }
 impl MaterialParameter for Vec3 {
-	const SK_TYPE: u32 = material_param__material_param_vector3;
+	const SK_TYPE: u32 = unsafe { transmute::<IntType, u32>(material_param__material_param_vector3) };
 
 	fn as_raw(&self) -> *const c_void {
 		&self as *const _ as *const c_void
 	}
 }
 impl MaterialParameter for Texture {
-	const SK_TYPE: u32 = material_param__material_param_texture;
+	const SK_TYPE: u32 = unsafe { transmute::<IntType, u32>(material_param__material_param_texture) };
 
 	fn as_raw(&self) -> *const c_void {
 		self.tex.as_ptr() as *const c_void
@@ -124,17 +125,17 @@ impl Material {
 		}
 	}
 	pub fn set_transparency(&self, mode: Transparency) {
-		unsafe { stereokit_sys::material_set_transparency(self.material.as_ptr(), mode as u32) }
+		unsafe { stereokit_sys::material_set_transparency(self.material.as_ptr(), transmute::<u32,IntType>(mode as u32)) }
 	}
 	pub fn set_cull(&self, mode: Cull) {
-		unsafe { stereokit_sys::material_set_cull(self.material.as_ptr(), mode as u32) }
+		unsafe { stereokit_sys::material_set_cull(self.material.as_ptr(), transmute::<u32,IntType>(mode as u32)) }
 	}
 	pub fn set_wireframe(&self, wireframe: bool) {
-		unsafe { stereokit_sys::material_set_wireframe(self.material.as_ptr(), wireframe as i32) }
+		unsafe { stereokit_sys::material_set_wireframe(self.material.as_ptr(), transmute::<u32,IntType>(wireframe as u32)) }
 	}
 	pub fn set_depth_test(&self, depth_test_mode: DepthTest) {
 		unsafe {
-			stereokit_sys::material_set_depth_test(self.material.as_ptr(), depth_test_mode as u32)
+			stereokit_sys::material_set_depth_test(self.material.as_ptr(), transmute::<u32,IntType>(depth_test_mode as u32))
 		}
 	}
 	pub fn set_depth_write(&self, write_enabled: bool) {
@@ -174,7 +175,7 @@ impl Material {
 			material_set_param(
 				self.material.as_ptr(),
 				ustr::ustr(name).as_char_ptr(),
-				P::SK_TYPE,
+				transmute::<u32,IntType>(P::SK_TYPE),
 				value.as_raw(),
 			);
 		}

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -2,10 +2,10 @@ use crate::{
 	lifecycle::{DrawContext, StereoKitInstanceWrapper},
 	material::Material,
 	render::RenderLayer,
-	values::{color128_from, matrix_from, vec2_from, vec3_from, Color128, Matrix, Vec2, Vec3},
+	values::{color128_from, matrix_from, vec2_from, vec3_from, Color128, Matrix, Vec2, Vec3, IntType},
 	StereoKit,
 };
-use std::rc::{Rc, Weak};
+use std::{rc::{Rc, Weak}, mem::transmute};
 use std::{fmt::Error, ptr::NonNull};
 use stereokit_sys::{_mesh_t, bool32_t, mesh_draw};
 use crate::bounds::Bounds;
@@ -59,7 +59,7 @@ impl Mesh {
 				material.material.as_ptr(),
 				matrix_from(matrix),
 				color128_from(color_linear),
-				layer.bits(),
+				transmute::<u32,IntType>(layer.bits() as u32),
 			)
 		}
 	}

--- a/src/model.rs
+++ b/src/model.rs
@@ -4,10 +4,11 @@ use crate::mesh::Mesh;
 use crate::pose::Pose;
 use crate::render::RenderLayer;
 use crate::shader::Shader;
-use crate::values::{color128_from, matrix_from, Color128, Matrix, Vec3, vec3_from, vec3_to};
+use crate::values::{color128_from, matrix_from, Color128, Matrix, Vec3, vec3_from, vec3_to, IntType};
 use crate::StereoKit;
 use std::ffi::{c_void, CString};
 use std::fmt::Error;
+use std::mem::transmute;
 use std::path::Path;
 use std::ptr::{null, null_mut, NonNull};
 use std::rc::{Rc, Weak};
@@ -79,7 +80,7 @@ impl Model {
 				self.model.as_ptr(),
 				matrix_from(matrix),
 				color128_from(color_linear),
-				layer.bits(),
+				transmute::<u32,IntType>(layer.bits() as u32),
 			)
 		}
 	}

--- a/src/sprite.rs
+++ b/src/sprite.rs
@@ -1,8 +1,10 @@
+use std::mem::transmute;
 use std::ptr::{NonNull, null_mut};
 use stereokit_sys::{_model_t, _sprite_t};
 use ustr::ustr;
 use crate::lifecycle::StereoKitInstanceWrapper;
 use crate::StereoKit;
+use crate::values::IntType;
 
 pub struct Sprite {
     sk: StereoKitInstanceWrapper,
@@ -24,7 +26,7 @@ impl Sprite {
         Self {
             sk: sk.get_wrapper(),
             sprite: NonNull::new(unsafe {
-                stereokit_sys::sprite_create_file(ustr(file).as_char_ptr(), sprite_type as u32, ustr("").as_char_ptr())
+                stereokit_sys::sprite_create_file(ustr(file).as_char_ptr(), transmute::<u32,IntType>(sprite_type as u32), ustr("").as_char_ptr())
             }).unwrap()
         }
     }

--- a/src/text.rs
+++ b/src/text.rs
@@ -4,7 +4,7 @@ use crate::font::Font;
 use crate::lifecycle::{DrawContext, StereoKitInstanceWrapper};
 use crate::values::{
 	color128_from, color32_from, matrix_from, vec2_from, vec2_to, Color128, Color32, Matrix, Vec2,
-	Vec3,
+	Vec3, IntType,
 };
 use crate::StereoKit;
 use bitflags::bitflags;
@@ -12,6 +12,7 @@ use bitflags_serde_shim::impl_serde_for_bitflags;
 use num_enum::TryFromPrimitive;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
+use std::mem::transmute;
 use std::rc::{Rc, Weak};
 use stereokit_sys::{text_add_at, text_add_in, text_make_style, text_size, text_style_t};
 
@@ -95,8 +96,8 @@ pub fn draw_at(
 			text.as_char_ptr(),
 			&matrix_from(transform.into()),
 			style.text_style,
-			position.bits(),
-			align.bits(),
+			transmute::<u32,IntType>(position.bits() as u32),
+			transmute::<u32,IntType>(align.bits() as u32),
 			offset.x,
 			offset.y,
 			offset.z,
@@ -124,10 +125,10 @@ pub fn draw_in(
 			text.as_char_ptr(),
 			&matrix_from(transform.into()),
 			vec2_from(size.into()),
-			fit as u32,
+			transmute::<u32,IntType>(fit as u32),
 			style.text_style,
-			position.bits(),
-			align.bits(),
+			transmute::<u32,IntType>(position.bits() as u32),
+			transmute::<u32,IntType>(align.bits() as u32),
 			offset.x,
 			offset.y,
 			offset.z,

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -3,13 +3,14 @@
 use crate::lifecycle::StereoKitInstanceWrapper;
 use crate::render::SphericalHarmonics;
 use crate::values::{
-	color128_from, color128_to, color32_from, color32_to, Color128, Color32, Vec3,
+	color128_from, color128_to, color32_from, color32_to, Color128, Color32, Vec3, IntType,
 };
 use crate::StereoKit;
 use bitflags::bitflags;
 use num_enum::TryFromPrimitive;
 use std::ffi::{c_void, CString};
 use std::fmt::Error;
+use std::mem::transmute;
 use std::path::Path;
 use std::ptr::NonNull;
 use std::rc::{Rc, Weak};
@@ -193,7 +194,7 @@ impl Texture {
 		Some(Texture {
 			sk: sk.get_wrapper(),
 			tex: NonNull::new(unsafe {
-				stereokit_sys::tex_create(texture_type.bits(), format as u32)
+				stereokit_sys::tex_create(transmute::<u32,IntType>(texture_type.bits() as u32), transmute::<u32,IntType>(format as u32))
 			})?,
 		})
 	}
@@ -306,7 +307,7 @@ impl Texture {
 		stereokit_sys::tex_set_surface(
 			self.tex.as_ptr(),
 			native_texture as *mut c_void,
-			texture_type.bits(),
+			transmute::<u32,IntType>(texture_type.bits() as u32),
 			native_format,
 			width as i32,
 			height as i32,
@@ -316,10 +317,10 @@ impl Texture {
 	}
 
 	pub unsafe fn set_sample(&self, sample: TextureSample) {
-		stereokit_sys::tex_set_sample(self.tex.as_ptr(), sample as u32);
+		stereokit_sys::tex_set_sample(self.tex.as_ptr(), transmute::<u32,IntType>(sample as u32));
 	}
 	pub unsafe fn set_address_mode(&self, address_mode: TextureAddress) {
-		stereokit_sys::tex_set_address(self.tex.as_ptr(), address_mode as u32);
+		stereokit_sys::tex_set_address(self.tex.as_ptr(), transmute::<u32,IntType>(address_mode as u32));
 	}
 	pub unsafe fn set_anisotropy_level(&self, anisotropy_level: i32) {
 		stereokit_sys::tex_set_anisotropy(self.tex.as_ptr(), anisotropy_level);

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -4,14 +4,16 @@ use crate::{
 	values::{vec2_from, Vec2},
 };
 use num_enum::TryFromPrimitive;
-use std::{ffi::CString, marker::PhantomData};
+use std::{ffi::CString, marker::PhantomData, mem::transmute};
 use stereokit_sys::{bool32_t, pose_t, text_align_, text_make_style, text_style_get_material, text_style_t, ui_btn_layout_, ui_button, ui_button_at, ui_button_img, ui_button_img_16, ui_button_img_at, ui_button_img_sz, ui_hslider, ui_label, ui_move_, ui_pop_text_style, ui_push_text_style, ui_sameline, ui_settings, ui_space, ui_text, ui_win_};
 use ustr::ustr;
 use crate::sprite::Sprite;
 use crate::font::Font;
+#[cfg(feature = "high-level")]
 use crate::high_level::text::Text;
 use crate::text::TextStyle;
 use crate::values::{Vec3, vec3_from};
+use crate::values::IntType;
 
 #[derive(Debug, Clone, Copy, TryFromPrimitive)]
 #[repr(u32)]
@@ -98,7 +100,7 @@ impl WindowContext {
 	}
 	pub fn text(&self, text: &str, text_align: TextAlign) {
 		let text = ustr(text);
-		unsafe { ui_text(text.as_char_ptr(), text_align.bits()) }
+		unsafe { ui_text(text.as_char_ptr(), transmute::<u32,IntType>(text_align.bits() as u32)) }
 	}
 	pub fn label(&self, text: &str, use_padding: bool) {
 		let text = ustr(text);
@@ -110,7 +112,7 @@ impl WindowContext {
 	}
 	pub fn button_image(&self, text: &str, sprite: &Sprite, layout: ButtonLayout) -> bool {
 		unsafe {
-			ui_button_img(ustr(text).as_char_ptr(), sprite.sprite.as_ptr(), layout as u32) != 0
+			ui_button_img(ustr(text).as_char_ptr(), sprite.sprite.as_ptr(), transmute::<u32,IntType>(layout as u32)) != 0
 		}
 	}
 	pub fn button_at(&self, text: &str, window_relative_pos: Vec3, size: Vec2) -> bool {
@@ -120,12 +122,12 @@ impl WindowContext {
 	}
 	pub fn button_image_at(&self, text: &str, sprite: &Sprite, layout: ButtonLayout, window_relative_pos: Vec3, size: Vec2) -> bool {
 		unsafe {
-			ui_button_img_at(ustr(text).as_char_ptr(), sprite.sprite.as_ptr(), layout as u32, vec3_from(window_relative_pos), vec2_from(size)) != 0
+			ui_button_img_at(ustr(text).as_char_ptr(), sprite.sprite.as_ptr(), transmute::<u32,IntType>(layout as u32), vec3_from(window_relative_pos), vec2_from(size)) != 0
 		}
 	}
 	pub fn slider(&self, text: &str, val: &mut f32, min: f32, max: f32, step: f32, width: f32, confirm_method: ConfirmMethod) {
 		unsafe {
-			ui_hslider(ustr(text).as_char_ptr(), val as *mut f32, min, max, step, width,confirm_method as u32, 0);
+			ui_hslider(ustr(text).as_char_ptr(), val as *mut f32, min, max, step, width,transmute::<u32,IntType>(confirm_method as u32), 0);
 		}
 	}
 	pub fn text_style(&self, text_style: TextStyle, content_closure: impl FnOnce(&WindowContext)) {

--- a/src/values.rs
+++ b/src/values.rs
@@ -135,3 +135,8 @@ pub(crate) fn quat_from(q: Quat) -> quat {
 pub(crate) fn quat_to(q: quat) -> Quat {
 	Quat::from([q.x, q.y, q.z, q.w])
 }
+
+#[cfg(target_os="windows")]
+pub type IntType = i32;
+#[cfg(not(target_os="windows"))]
+pub type IntType = u32;


### PR DESCRIPTION
- Added an IntType which is the type that the compiler wants for stereokit methods (even though those methods require a u32 anyway)
- Changed method calls that used u32 to instead reinterpret the cast without changing the value using transmute
- Updated stereokit-sys to 2.0.1 which has a windows fix
- Added .vscode and .idea directories to .gitignore to not save local settings with git